### PR TITLE
タイトルの取得に失敗するケースの対応

### DIFF
--- a/backend/app/chat.py
+++ b/backend/app/chat.py
@@ -2,21 +2,26 @@ from fastapi import status
 from fastapi_custom_route import LOGGER
 from openai import BadRequestError, OpenAI
 
+TITLE_PROMPT =  ("入力された内容を要約してタイトルを生成してください。\n"
+                 "また生成場合は出力フォーマットにしたがってください。\n\n"
+                 "## 出力フォーマット\n"
+                 "文字列\n\n"
+                 "## 出力例\n"
+                 "これはタイトル！\n\n"
+                 "## 入力された内容\n"
+                 "{message}\n\n"
+                 "## タイトル\n")
 
 def generate_title(message: str):
+    """
+    入力された内容を要約してタイトルを生成する
+    """
 
-    prompt = ("入力された内容を要約してタイトルを生成してください。\n"
-              "また生成場合は出力フォーマットにしたがってください。\n\n"
-              "## 出力フォーマット\n"
-              "文字列\n\n"
-              "## 出力例\n"
-              "これはタイトル！\n\n"
-              "## 入力された内容\n"
-              "{message}\n\n"
-              "## タイトル\n")
-    content = prompt.format(message=message)
+    content = TITLE_PROMPT.format(message=message)
     default_model = "gpt-3.5-turbo"
     title, _ = chat_request([{"role": "user", "content": content}], default_model)
+    if title == "":
+        return message.split("\n")[0]
     return title
 
 

--- a/backend/tests/test_chat.py
+++ b/backend/tests/test_chat.py
@@ -1,7 +1,19 @@
 from unittest.mock import MagicMock, patch
 
-from chat import chat_request
+from chat import chat_request, generate_title
 from fastapi import status
+
+
+def test_generate_title():
+    with patch('chat.chat_request') as mock_chat_request:
+        mock_chat_request.return_value = ("title", status.HTTP_200_OK)
+        message = "test message"
+        title = generate_title(message)
+        assert title == "title"
+
+        mock_chat_request.return_value = ("", status.HTTP_500_INTERNAL_SERVER_ERROR)
+        title = generate_title(message)
+        assert title == "test message"
 
 
 def test_chat_request():


### PR DESCRIPTION
## 更新内容
- タイトル取得に失敗した場合にメッセージの一部をタイトルに設定するように修正 (#148)