### PR TITLE
GET /history から GET /chat にリネーム

### DIFF
--- a/backend/app/app.py
+++ b/backend/app/app.py
@@ -23,7 +23,7 @@ from response_type import (
     ErrorResponse,
     ResponseDeleteChat,
     ResponseGetChat,
-    ResponseGetHistory,
+    ResponseGetChatMessage,
     ResponseGetModels,
     ResponseHello,
     ResponsePostChat,
@@ -48,11 +48,11 @@ app.router.route_class = ContextIncludedRoute
 def hello() -> dict[str, str]:
     return ResponseHello(message="Hello, world!")
 
-@app.get("/history", response_model=ResponseGetHistory)
-def history(page: int=1) -> dict[str, list]:
+@app.get("/chat", response_model=ResponseGetChat)
+def get_chat(page: int=1) -> dict[str, list]:
 
     res = get_messages(page)
-    return ResponseGetHistory(history=res["history"],
+    return ResponseGetChat(history=res["history"],
                               current_page=res["current_page"],
                               next_page=res["next_page"],
                               total_page=res["total_pages"])
@@ -62,10 +62,10 @@ def get_models() -> dict[str, list]:
     models = db_get_models()
     return ResponseGetModels(models=models)
 
-@app.get("/chat/{message_id}", response_model=ResponseGetChat)
-def get_chat(message_id: int) -> dict[str, list]:
+@app.get("/chat/{message_id}", response_model=ResponseGetChatMessage)
+def get_chat_message(message_id: int) -> dict[str, list]:
     messages = select_message_details(message_id, required_column={"role", "message", "model"})
-    return ResponseGetChat(messages=messages)
+    return ResponseGetChatMessage(messages=messages)
 
 @app.delete("/chat/{message_id}",
             response_model=ResponseDeleteChat,

--- a/backend/app/response_type.py
+++ b/backend/app/response_type.py
@@ -8,7 +8,7 @@ class ResponseHello(BaseModel):
     message: str = None
     model_config = ConfigDict(extra="forbid") # レスポンスに含まれるフィールドを制限する
 
-class ResponseGetHistoryContent(BaseModel):
+class ResponseGetChatContent(BaseModel):
     """
     Get /historyのレスポンスのhistoryの要素のcontentの要素
     """
@@ -16,11 +16,11 @@ class ResponseGetHistoryContent(BaseModel):
     title: str
     model_config = ConfigDict(extra="forbid")
 
-class ResponseGetHistory(BaseModel):
+class ResponseGetChat(BaseModel):
     """
     Get /historyのレスポンスのhistoryの要素
     """
-    history: list[ResponseGetHistoryContent]
+    history: list[ResponseGetChatContent]
     current_page: int
     next_page: int = None
     total_page: int
@@ -43,7 +43,7 @@ class ResponseGetModels(BaseModel):
     models: list[ResponseGetModel]
     model_config = ConfigDict(extra="forbid")
 
-class ResponseGetChatMessage(BaseModel):
+class ResponseGetChatMessageDetail(BaseModel):
     """
     Get /chat/{message_id}のレスポンスのmessagesの要素
     """
@@ -52,11 +52,11 @@ class ResponseGetChatMessage(BaseModel):
     model: str | None = None
     model_config = ConfigDict(extra="forbid")
 
-class ResponseGetChat(BaseModel):
+class ResponseGetChatMessage(BaseModel):
     """
     Get /chat/{message_id}のレスポンス
     """
-    messages: list[ResponseGetChatMessage] = None
+    messages: list[ResponseGetChatMessageDetail] = None
     model_config = ConfigDict(extra="forbid")
 
 class ResponseDeleteChat(BaseModel):

--- a/frontend/src/chat.ts
+++ b/frontend/src/chat.ts
@@ -262,7 +262,7 @@ import { Utils } from "./utils.js";
   }
 
   function generateHistoryList() {
-    const url = Utils.getEndpoint("/app/history");
+    let url = Utils.getEndpoint("/app/chat");
     const history_list = new HistoryList();
     Utils.request(url, "GET", null, function (xhr) {
       if (xhr.readyState === XMLHttpRequest.DONE && xhr.status === 200) {


### PR DESCRIPTION
## 更新内容
- API エンドポイント名を更新 (#115)
  - GET /history から GET /chat に変更 