### PR TITLE
非同期でタイトルを生成するように更新

### DIFF
--- a/backend/app/chat.py
+++ b/backend/app/chat.py
@@ -9,11 +9,13 @@ from openai import OpenAI
 
 TITLE_PROMPT = (
     "入力された内容を要約してタイトルを生成してください。\n"
-    "また生成場合は出力フォーマットにしたがってください。\n\n"
+    "また出力フォーマットにしたがってください。\n\n"
     "## 出力フォーマット\n"
     "文字列\n\n"
+    "## 入力例\n"
+    "ここにメッセージが入ります。\n\n"
     "## 出力例\n"
-    "これはタイトル！\n\n"
+    "タイトルA\n\n"
     "## 入力された内容\n"
     "{message}\n\n"
     "## タイトル\n"
@@ -29,7 +31,7 @@ def generate_title(message: str):
     default_model = "gpt-4o-mini-2024-07-18"
     title, http_staus = chat_openai([{"role": "user", "content": content}], default_model)
     if title == "":
-        return message.split("\n")[0]
+        return ""
     return title.rstrip()
 
 

--- a/backend/app/db.py
+++ b/backend/app/db.py
@@ -55,6 +55,15 @@ def insert_message(title: str) -> int:
     return res.lastrowid
 
 
+def update_message(message_id: int, title: str) -> None:
+    """Update message"""
+    conn = connect_db()
+    cur = conn.cursor()
+    sql = "UPDATE messages SET title = ? WHERE id = ?;"
+    cur.execute(sql, (title, message_id))
+    conn.commit()
+
+
 def insert_message_details(mid: int, role: str, model: str, contents: dict) -> None:
     """Insert message_details"""
 

--- a/backend/app/response_type.py
+++ b/backend/app/response_type.py
@@ -100,6 +100,15 @@ class ResponsePostMessage(BaseModel):
     model_config = ConfigDict(extra="forbid")
 
 
+class ResponsePostGenerateTitle(BaseModel):
+    """
+    Post /generate/titleのレスポンス
+    """
+
+    title: str
+    model_config = ConfigDict(extra="forbid")
+
+
 class ErrorResponse(BaseModel):
     message: str = None
     model_config = ConfigDict(extra="forbid")

--- a/backend/tests/test_chat.py
+++ b/backend/tests/test_chat.py
@@ -14,7 +14,7 @@ def test_generate_title():
 
         mock_chat_request.return_value = ("", status.HTTP_500_INTERNAL_SERVER_ERROR)
         title = generate_title(message)
-        assert title == "test message"
+        assert title == ""
 
 
 def test_chat_openai():


### PR DESCRIPTION
## 更新内容
- 新規のメッセージを生成する時点でタイトルを設定できるように更新 (#193)
- PUT /messages/{message_id} にてタイトルを更新できるように修正 (#204)